### PR TITLE
Approve されたらユーザ名をラベル付けする

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
     "env": {
         "browser": true,
-        "es2021": true
+        "es2021": true,
+        "jest/globals": true
     },
     "extends": [
         "eslint:recommended",
@@ -14,7 +15,8 @@
         "sourceType": "module"
     },
     "plugins": [
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "jest"
     ],
     "rules": {
     }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 on:
-  - pull_request
+  - pull_request_review
 
 jobs:
   label_job:
     runs-on: ubuntu-latest
-    name: A job to Label to PullRequest
+    name: A job to Label to PullRequest when approved
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,16 @@
-name: Run Jest
+# name: Run Jest
 
-on:
-  pull_request:
-    types: [opened]
+# on:
+#   pull_request:
+#     types: [opened]
 
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    name: A job to run jest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - run: npm ci
-      - name: Run test
-        run: npx jest
+# jobs:
+#   build:
+#     runs-on: ubuntu-latest
+#     name: A job to run jest
+#     steps:
+#       - name: checkout
+#         uses: actions/checkout@v2
+#       - run: npm ci
+#       - name: Run test
+#         run: npx jest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,16 @@
-# name: Run Jest
+name: Run Jest
 
-# on:
-#   pull_request:
-#     types: [opened]
+on:
+  pull_request:
+    types: [opened]
 
-# jobs:
-#   build:
-#     runs-on: ubuntu-latest
-#     name: A job to run jest
-#     steps:
-#       - name: checkout
-#         uses: actions/checkout@v2
-#       - run: npm ci
-#       - name: Run test
-#         run: npx jest
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: A job to run jest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - run: npm ci
+      - name: Run test
+        run: npx jest

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -22,80 +22,117 @@ describe('mockInput', () => {
 
 test('succeess: label to pr', async () => {
   // @ts-ignore
+  // ある程度必要な情報を定義
   github.context = {
     payload: {
-      action: 'opened',
-      number: '1',
+      action: "submitted",
       pull_request: {
-        labels: [],
-        number: 1,
-        title: 'test',
-        user: {
-          login: 'pr-creator',
+        assignee: null,
+        assignees: [],
+        auto_merge: null,
+        base: {
+          ref: "master",
         },
+        closed_at: null,
+        draft: false,
+        labels: ["labeled"],
       },
-      repository: {
-        name: 'label-when-approved-action',
-        owner: {
-          login: 'shin-shin-01',
-        },
+      review: {
+        state: "approved",
       },
     },
-    issue: {
-      owner: 'label-when-approved-action',
-      repo: 'shin-shin-01',
-      number: 1,
-    },
+    eventName: "pull_request_review",
+    actor: "Kaze-for-test",
   }
   /* 
   client = github.getOctokit(myToken) より client: undefined になる
   addLabels: client.issues.addLabels ->  エラーが発生するため
   モックとして作成し，Promise<void>を返すようにしておく
   */
-  const addLabelsSpy = jest.spyOn(PullRequest.prototype, 'addLabels').mockReturnValue(Promise.resolve());
-  const hasAnyLabelSpy = jest.spyOn(PullRequest.prototype, 'hasAnyLabel')
+ const isApprovedSpy = jest.spyOn(PullRequest.prototype, 'isApproved')
+ const getUserNameSpy = jest.spyOn(PullRequest.prototype, 'getUserName')
+ const hasAnyLabelSpy = jest.spyOn(PullRequest.prototype, 'hasAnyLabel')
+ const addLabelsSpy = jest.spyOn(PullRequest.prototype, 'addLabels').mockReturnValue(Promise.resolve());
 
-  await main()
-  expect(hasAnyLabelSpy).toHaveBeenCalled()
-  expect(addLabelsSpy).toHaveBeenCalled()
+ await main()
+ expect(isApprovedSpy).toHaveBeenCalled()
+ expect(getUserNameSpy).toHaveBeenCalled()
+ expect(hasAnyLabelSpy).toHaveBeenCalled()
+ expect(addLabelsSpy).toHaveBeenCalled()
+ // ユーザ名の確認
+ expect(new PullRequest('token', github.context).getUserName()).toBe("Kaze-for-test")
 })
   
-test('failuer: already labeled', async () => {
+test('failuer: review is not APPROVED', async () => {
   // @ts-ignore
   github.context = {
     payload: {
-      action: 'opened',
-      number: '1',
+      action: "submitted",
       pull_request: {
+        assignee: null,
+        assignees: [],
+        auto_merge: null,
+        base: {
+          ref: "master",
+        },
+        closed_at: null,
+        draft: false,
         labels: ["labeled"],
-        number: 1,
-        title: 'test',
-        user: {
-          login: 'pr-creator',
-        },
       },
-      repository: {
-        name: 'label-when-approved-action',
-        owner: {
-          login: 'shin-shin-01',
-        },
+      review: {
+        state: "commented", // not approved
       },
     },
-    issue: {
-      owner: 'label-when-approved-action',
-      repo: 'shin-shin-01',
-      number: 1,
-    },
+    eventName: "pull_request_review",
+    actor: "Kaze-for-test",
   }
-  /* 
-  client = github.getOctokit(myToken) より client: undefined になる
-  addLabels: client.issues.addLabels ->  エラーが発生するため
-  モックとして作成し，Promise<void>を返すようにしておく
-  */
-  const addLabelsSpy = jest.spyOn(PullRequest.prototype, 'addLabels').mockReturnValue(Promise.resolve());
+  
+  const isApprovedSpy = jest.spyOn(PullRequest.prototype, 'isApproved')
+  const getUserNameSpy = jest.spyOn(PullRequest.prototype, 'getUserName')
   const hasAnyLabelSpy = jest.spyOn(PullRequest.prototype, 'hasAnyLabel')
+  const addLabelsSpy = jest.spyOn(PullRequest.prototype, 'addLabels').mockReturnValue(Promise.resolve());
 
   await main()
+  expect(isApprovedSpy).toHaveBeenCalled()
+  expect(getUserNameSpy).not.toHaveBeenCalled()
+  expect(hasAnyLabelSpy).not.toHaveBeenCalled()
+  expect(addLabelsSpy).not.toHaveBeenCalled()
+})
+
+test('failuer: already labeled by reviewer', async () => {
+  // @ts-ignore
+  github.context = {
+    payload: {
+      action: "submitted",
+      pull_request: {
+        assignee: null,
+        assignees: [],
+        auto_merge: null,
+        base: {
+          ref: "master",
+        },
+        closed_at: null,
+        draft: false,
+        labels: ["Kaze-for-test"], // already labeled
+      },
+      review: {
+        state: "approved",
+      },
+    },
+    eventName: "pull_request_review",
+    actor: "Kaze-for-test",
+  }
+  
+  const isApprovedSpy = jest.spyOn(PullRequest.prototype, 'isApproved')
+  const getUserNameSpy = jest.spyOn(PullRequest.prototype, 'getUserName')
+  const hasAnyLabelSpy = jest.spyOn(PullRequest.prototype, 'hasAnyLabel')
+  const addLabelsSpy = jest.spyOn(PullRequest.prototype, 'addLabels').mockReturnValue(Promise.resolve());
+
+  await main()
+  expect(isApprovedSpy).toHaveBeenCalled()
+  expect(getUserNameSpy).toHaveBeenCalled()
   expect(hasAnyLabelSpy).toHaveBeenCalled()
   expect(addLabelsSpy).not.toHaveBeenCalled()
+  // ユーザ名の確認
+ expect(new PullRequest('token', github.context).getUserName()).toBe("Kaze-for-test")
 })

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Hello World'
-description: 'Label to PullRequest'
+name: 'Label to PullRequest when approved'
+description: 'Label to PullRequest when approved'
 inputs:
   MYTOKEN: # id of input
     description: 'github token'

--- a/dist/index.js
+++ b/dist/index.js
@@ -43,9 +43,6 @@ function main() {
             console.log("created client");
             const pr = new pull_request_1.PullRequest(client, github.context);
             console.log("created PullRequest");
-            // to debug
-            const context = JSON.stringify(github.context, undefined, 2);
-            console.log(`The event context: ${context}`);
             // Approved されているか？
             if (pr.isApproved()) {
                 // ユーザ名取得

--- a/dist/index.js
+++ b/dist/index.js
@@ -43,6 +43,9 @@ function main() {
             console.log("created client");
             const pr = new pull_request_1.PullRequest(client, github.context);
             console.log("created PullRequest");
+            // to debug
+            const context = JSON.stringify(github.context, undefined, 2);
+            console.log(`The event context: ${context}`);
             // Approved されているか？
             if (pr.isApproved()) {
                 // ユーザ名取得

--- a/dist/index.js
+++ b/dist/index.js
@@ -43,11 +43,21 @@ function main() {
             console.log("created client");
             const pr = new pull_request_1.PullRequest(client, github.context);
             console.log("created PullRequest");
-            if (!pr.hasAnyLabel(["labeled"])) {
-                yield pr.addLabels(["labeled"]);
+            // Approved されているか？
+            if (pr.isApproved()) {
+                // ユーザ名取得
+                const username = pr.getUserName();
+                // ユーザ名で既に Label付けされているか？
+                if (!pr.hasAnyLabel([username])) {
+                    // ラベル付与
+                    yield pr.addLabels([username]);
+                }
+                else {
+                    console.log("already labeled");
+                }
             }
             else {
-                console.log("already labeledToken");
+                console.log("not Approved");
             }
         }
         catch (error) {

--- a/dist/pull_request.d.ts
+++ b/dist/pull_request.d.ts
@@ -5,4 +5,6 @@ export declare class PullRequest {
     constructor(client: any, context: Context);
     addLabels(labels: string[]): Promise<void>;
     hasAnyLabel(labels: string[]): boolean;
+    getUserName(): string;
+    isApproved(): boolean;
 }

--- a/dist/pull_request.js
+++ b/dist/pull_request.js
@@ -37,6 +37,8 @@ class PullRequest {
     }
     addLabels(labels) {
         return __awaiter(this, void 0, void 0, function* () {
+            // Action実行時に取得できる情報
+            // @see https://github.com/actions/toolkit/blob/825204968bef6c9829341275d8a35de5702dd965/packages/github/src/context.ts#L6
             const { owner, repo, number: pull_number } = this.context.issue;
             console.log(`owner: ${owner}`);
             console.log(`repo: ${repo}`);
@@ -57,6 +59,17 @@ class PullRequest {
         const pullRequestLabels = this.context.payload.pull_request
             .labels;
         return pullRequestLabels.some(label => labels.includes(label));
+    }
+    // review 時の payload @see https://docs.github.com/en/rest/reference/pulls#reviews
+    // review をしたユーザ名を取得
+    getUserName() {
+        const username = this.context.payload.user.login;
+        return username;
+    }
+    // Review によって Approved されているか？
+    isApproved() {
+        const state = this.context.payload.state;
+        return state == "APPROVED";
     }
 }
 exports.PullRequest = PullRequest;

--- a/dist/pull_request.js
+++ b/dist/pull_request.js
@@ -63,13 +63,13 @@ class PullRequest {
     // review 時の payload @see https://docs.github.com/en/rest/reference/pulls#reviews
     // review をしたユーザ名を取得
     getUserName() {
-        const username = this.context.payload.user.login;
+        const username = this.context.actor;
         return username;
     }
     // Review によって Approved されているか？
     isApproved() {
-        const state = this.context.payload.state;
-        return state == "APPROVED";
+        const state = this.context.payload.review.state;
+        return state == "approved";
     }
 }
 exports.PullRequest = PullRequest;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,19 @@ export async function main() {
     const pr = new PullRequest(client, github.context);
     console.log("created PullRequest");
 
-    if (!pr.hasAnyLabel(["labeled"])) {
-      await pr.addLabels(["labeled"]);
+    // Approved されているか？
+    if (pr.isApproved()) {
+      // ユーザ名取得
+      const username: string = pr.getUserName();
+      // ユーザ名で既に Label付けされているか？
+      if (!pr.hasAnyLabel([username])) {
+        // ラベル付与
+        await pr.addLabels([username]);
+      } else {
+        console.log("already labeled");
+      }
     } else {
-      console.log("already labeledToken");
+      console.log("not Approved");
     }
   } catch (error) {
     console.log(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ export async function main() {
     console.log("created PullRequest");
 
     // to debug
-    console.log(github.context);
+    const context: string = JSON.stringify(github.context, undefined, 2);
+    console.log(`The event context: ${context}`);
 
     // Approved されているか？
     if (pr.isApproved()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,6 @@ export async function main() {
     const pr = new PullRequest(client, github.context);
     console.log("created PullRequest");
 
-    // to debug
-    const context: string = JSON.stringify(github.context, undefined, 2);
-    console.log(`The event context: ${context}`);
-
     // Approved されているか？
     if (pr.isApproved()) {
       // ユーザ名取得

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,9 @@ export async function main() {
     const pr = new PullRequest(client, github.context);
     console.log("created PullRequest");
 
+    // to debug
+    console.log(github.context);
+
     // Approved されているか？
     if (pr.isApproved()) {
       // ユーザ名取得

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,12 @@ export async function main() {
     console.log("created PullRequest");
 
     // to debug
-    const context: string = JSON.stringify(github.context, undefined, 2);
-    console.log(`The event context: ${context}`);
+    const payload: string = JSON.stringify(
+      github.context.payload,
+      undefined,
+      2
+    );
+    console.log(`The event payload: ${payload}`);
 
     // Approved されているか？
     if (pr.isApproved()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,8 @@ export async function main() {
     console.log("created PullRequest");
 
     // to debug
-    const payload: string = JSON.stringify(
-      github.context.payload,
-      undefined,
-      2
-    );
-    console.log(`The event payload: ${payload}`);
+    const context: string = JSON.stringify(github.context, undefined, 2);
+    console.log(`The event context: ${context}`);
 
     // Approved されているか？
     if (pr.isApproved()) {

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -42,13 +42,13 @@ export class PullRequest {
   // review 時の payload @see https://docs.github.com/en/rest/reference/pulls#reviews
   // review をしたユーザ名を取得
   getUserName(): string {
-    const username: string = this.context.payload.user.login;
+    const username: string = this.context.actor;
     return username;
   }
 
   // Review によって Approved されているか？
   isApproved(): boolean {
-    const state: string = this.context.payload.state;
-    return state == "APPROVED";
+    const state: string = this.context.payload.review.state;
+    return state == "approved";
   }
 }

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -49,6 +49,7 @@ export class PullRequest {
   // Review によって Approved されているか？
   isApproved(): boolean {
     const state: string = this.context.payload.state;
+    console.log(this.context);
     return state == "APPROVED";
   }
 }

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -49,7 +49,6 @@ export class PullRequest {
   // Review によって Approved されているか？
   isApproved(): boolean {
     const state: string = this.context.payload.state;
-    console.log(this.context);
     return state == "APPROVED";
   }
 }

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -12,6 +12,8 @@ export class PullRequest {
   }
 
   async addLabels(labels: string[]): Promise<void> {
+    // Action実行時に取得できる情報
+    // @see https://github.com/actions/toolkit/blob/825204968bef6c9829341275d8a35de5702dd965/packages/github/src/context.ts#L6
     const { owner, repo, number: pull_number } = this.context.issue;
     console.log(`owner: ${owner}`);
     console.log(`repo: ${repo}`);

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -38,4 +38,17 @@ export class PullRequest {
 
     return pullRequestLabels.some(label => labels.includes(label));
   }
+
+  // review 時の payload @see https://docs.github.com/en/rest/reference/pulls#reviews
+  // review をしたユーザ名を取得
+  getUserName(): string {
+    const username: string = this.context.payload.user.login;
+    return username;
+  }
+
+  // Review によって Approved されているか？
+  isApproved(): boolean {
+    const state: string = this.context.payload.state;
+    return state == "APPROVED";
+  }
 }


### PR DESCRIPTION
## 概要
Approved. されたらユーザ名をラベル付けするように作成

## 詳細（主に技術的変更点）

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）
自分のPRに review できないことに気づいた...
→ 何かツールを使用して PR を出してもらうようにしないと

## 保留した項目・TODOリスト
- [x] テストを作成
- [ ] 再度リクエストが投げられた時に一旦ラベルを外す機能を実装
- [ ] ラベルの色を変更
 
## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
* action 実行タイミング `pull_request_review`
https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#pull_request_review
* review時に 取得できる情報　（`State`や`user.login`）
https://docs.github.com/en/rest/reference/pulls#reviews
→ https://github.com/shin-shin-01/label-when-approved-action/runs/2013290440?check_suite_focus=true
* eslint-plugin-jest の導入
https://oisham.hatenablog.com/entry/2019/08/20/111826