### PR TITLE
ReviewRequest時にラベルを削除する

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 on:
+  # レビュー依頼を行なった時
+  pull_request:
+    types:
+      - review_requested
+  # レビューをしたとき
   - pull_request_review
-
+  
 jobs:
   label_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
     types:
       - review_requested
   # レビューをしたとき
-  - pull_request_review
+  pull_request_review:
   
 jobs:
   label_job:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Run Jest
 
 on:
   pull_request:
-    types: [opened]
+    types: [closed]
 
 jobs:
   build:

--- a/dist/index.js
+++ b/dist/index.js
@@ -43,22 +43,10 @@ function main() {
             console.log("created client");
             const pr = new pull_request_1.PullRequest(client, github.context);
             console.log("created PullRequest");
-            // Approved されているか？
-            if (pr.isApproved()) {
-                // ユーザ名取得
-                const username = pr.getUserName();
-                // ユーザ名で既に Label付けされているか？
-                if (!pr.hasAnyLabel([username])) {
-                    // ラベル付与
-                    yield pr.addLabels([username]);
-                }
-                else {
-                    console.log("already labeled");
-                }
-            }
-            else {
-                console.log("not Approved");
-            }
+            // to debug
+            const context = JSON.stringify(github.context, undefined, 2);
+            console.log(`The event context: ${context}`);
+            // await add_label_when_reviewd(pr);
         }
         catch (error) {
             console.log(error);
@@ -67,4 +55,24 @@ function main() {
     });
 }
 exports.main = main;
+function add_label_when_reviewd(pr) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // Approved されているか？
+        if (pr.isApproved()) {
+            // ユーザ名取得
+            const username = pr.getUserName();
+            // ユーザ名で既に Label付けされているか？
+            if (!pr.hasAnyLabel([username])) {
+                // ラベル付与
+                yield pr.addLabels([username]);
+            }
+            else {
+                console.log("already labeled");
+            }
+        }
+        else {
+            console.log("not Approved");
+        }
+    });
+}
 main();

--- a/dist/index.js
+++ b/dist/index.js
@@ -43,10 +43,12 @@ function main() {
             console.log("created client");
             const pr = new pull_request_1.PullRequest(client, github.context);
             console.log("created PullRequest");
-            // to debug
-            const context = JSON.stringify(github.context, undefined, 2);
-            console.log(`The event context: ${context}`);
-            // await add_label_when_reviewd(pr);
+            if (pr.actionIsReviewed()) {
+                yield add_label_when_reviewd(pr);
+            }
+            else if (pr.actionIsReviewRequested()) {
+                yield rm_label_when_rereview_requested(pr);
+            }
         }
         catch (error) {
             console.log(error);
@@ -72,6 +74,20 @@ function add_label_when_reviewd(pr) {
         }
         else {
             console.log("not Approved");
+        }
+    });
+}
+function rm_label_when_rereview_requested(pr) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // Review依頼している ユーザ名取得
+        const username = pr.getRequestedUserName();
+        // ユーザ名で既に Label付けされているか？
+        if (pr.hasAnyLabel([username])) {
+            // ラベル削除
+            yield pr.rmLabel(username);
+        }
+        else {
+            console.log("not labeled yet");
         }
     });
 }

--- a/dist/pull_request.d.ts
+++ b/dist/pull_request.d.ts
@@ -3,8 +3,12 @@ export declare class PullRequest {
     private client;
     private context;
     constructor(client: any, context: Context);
-    addLabels(labels: string[]): Promise<void>;
     hasAnyLabel(labels: string[]): boolean;
+    actionIsReviewed(): boolean;
     getUserName(): string;
     isApproved(): boolean;
+    addLabels(labels: string[]): Promise<void>;
+    actionIsReviewRequested(): boolean;
+    getRequestedUserName(): string;
+    rmLabel(name: string): Promise<void>;
 }

--- a/dist/pull_request.js
+++ b/dist/pull_request.js
@@ -41,6 +41,8 @@ class PullRequest {
         }
         const pullRequestLabels = this.context.payload.pull_request
             .labels;
+        console.log(pullRequestLabels);
+        console.log(labels);
         return pullRequestLabels.some(label => labels.includes(label));
     }
     // review 時の payload @see https://docs.github.com/en/rest/reference/pulls#reviews`

--- a/dist/pull_request.js
+++ b/dist/pull_request.js
@@ -35,6 +35,29 @@ class PullRequest {
         this.client = client;
         this.context = context;
     }
+    hasAnyLabel(labels) {
+        if (!this.context.payload.pull_request) {
+            return false;
+        }
+        const pullRequestLabels = this.context.payload.pull_request
+            .labels;
+        return pullRequestLabels.some(label => labels.includes(label));
+    }
+    // review 時の payload @see https://docs.github.com/en/rest/reference/pulls#reviews`
+    actionIsReviewed() {
+        const action = this.context.payload.action;
+        return action == "submitted";
+    }
+    // review をしたユーザ名を取得
+    getUserName() {
+        const username = this.context.actor;
+        return username;
+    }
+    // Review によって Approved されているか？
+    isApproved() {
+        const state = this.context.payload.review.state;
+        return state == "approved";
+    }
     addLabels(labels) {
         return __awaiter(this, void 0, void 0, function* () {
             // Action実行時に取得できる情報
@@ -52,24 +75,32 @@ class PullRequest {
             core.debug(JSON.stringify(result));
         });
     }
-    hasAnyLabel(labels) {
-        if (!this.context.payload.pull_request) {
-            return false;
-        }
-        const pullRequestLabels = this.context.payload.pull_request
-            .labels;
-        return pullRequestLabels.some(label => labels.includes(label));
+    // request Review
+    actionIsReviewRequested() {
+        const action = this.context.payload.action;
+        return action == "review_requested";
     }
-    // review 時の payload @see https://docs.github.com/en/rest/reference/pulls#reviews
-    // review をしたユーザ名を取得
-    getUserName() {
-        const username = this.context.actor;
+    // review を request したユーザ名を取得
+    getRequestedUserName() {
+        const username = this.context.payload.requested_reviewer.login;
         return username;
     }
-    // Review によって Approved されているか？
-    isApproved() {
-        const state = this.context.payload.review.state;
-        return state == "approved";
+    rmLabel(name) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Action実行時に取得できる情報
+            // @see https://github.com/actions/toolkit/blob/825204968bef6c9829341275d8a35de5702dd965/packages/github/src/context.ts#L6
+            const { owner, repo, number: pull_number } = this.context.issue;
+            console.log(`owner: ${owner}`);
+            console.log(`repo: ${repo}`);
+            console.log(`pull_number: ${pull_number}`);
+            const result = yield this.client.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: pull_number,
+                name
+            });
+            core.debug(JSON.stringify(result));
+        });
     }
 }
 exports.PullRequest = PullRequest;

--- a/dist/pull_request.js
+++ b/dist/pull_request.js
@@ -39,11 +39,8 @@ class PullRequest {
         if (!this.context.payload.pull_request) {
             return false;
         }
-        const pullRequestLabels = this.context.payload.pull_request
-            .labels;
-        console.log(pullRequestLabels);
-        console.log(labels);
-        return pullRequestLabels.some(label => labels.includes(label));
+        const pullRequestLabels = this.context.payload.pull_request.labels;
+        return pullRequestLabels.some(label => labels.includes(label.name));
     }
     // review 時の payload @see https://docs.github.com/en/rest/reference/pulls#reviews`
     actionIsReviewed() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,24 +15,32 @@ export async function main() {
     const pr = new PullRequest(client, github.context);
     console.log("created PullRequest");
 
-    // Approved されているか？
-    if (pr.isApproved()) {
-      // ユーザ名取得
-      const username: string = pr.getUserName();
-      // ユーザ名で既に Label付けされているか？
-      if (!pr.hasAnyLabel([username])) {
-        // ラベル付与
-        await pr.addLabels([username]);
-      } else {
-        console.log("already labeled");
-      }
-    } else {
-      console.log("not Approved");
-    }
+    // to debug
+    const context: string = JSON.stringify(github.context, undefined, 2);
+    console.log(`The event context: ${context}`);
+    // await add_label_when_reviewd(pr);
   } catch (error) {
     console.log(error);
     core.setFailed(error.message);
   }
+}
+
+async function add_label_when_reviewd(pr: PullRequest) {
+  // Approved されているか？
+  if (pr.isApproved()) {
+    // ユーザ名取得
+    const username: string = pr.getUserName();
+    // ユーザ名で既に Label付けされているか？
+    if (!pr.hasAnyLabel([username])) {
+      // ラベル付与
+      await pr.addLabels([username]);
+    } else {
+      console.log("already labeled");
+    }
+  } else {
+    console.log("not Approved");
+  }
+
 }
 
 main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,11 @@ export async function main() {
     const pr = new PullRequest(client, github.context);
     console.log("created PullRequest");
 
-    // to debug
-    const context: string = JSON.stringify(github.context, undefined, 2);
-    console.log(`The event context: ${context}`);
-    // await add_label_when_reviewd(pr);
+    if (pr.actionIsReviewed()) {
+      await add_label_when_reviewd(pr);
+    } else if (pr.actionIsReviewRequested()) {
+      await rm_label_when_rereview_requested(pr);
+    }
   } catch (error) {
     console.log(error);
     core.setFailed(error.message);
@@ -40,7 +41,18 @@ async function add_label_when_reviewd(pr: PullRequest) {
   } else {
     console.log("not Approved");
   }
+}
 
+async function rm_label_when_rereview_requested(pr: PullRequest) {
+  // Review依頼している ユーザ名取得
+  const username: string = pr.getRequestedUserName();
+  // ユーザ名で既に Label付けされているか？
+  if (pr.hasAnyLabel([username])) {
+    // ラベル削除
+    await pr.rmLabel(username);
+  } else {
+    console.log("not labeled yet");
+  }
 }
 
 main();

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -17,6 +17,8 @@ export class PullRequest {
     }
     const pullRequestLabels: string[] = this.context.payload.pull_request
       .labels;
+    console.log(pullRequestLabels);
+    console.log(labels);
 
     return pullRequestLabels.some(label => labels.includes(label));
   }

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -11,6 +11,34 @@ export class PullRequest {
     this.context = context;
   }
 
+  hasAnyLabel(labels: string[]): boolean {
+    if (!this.context.payload.pull_request) {
+      return false;
+    }
+    const pullRequestLabels: string[] = this.context.payload.pull_request
+      .labels;
+
+    return pullRequestLabels.some(label => labels.includes(label));
+  }
+
+  // review 時の payload @see https://docs.github.com/en/rest/reference/pulls#reviews`
+  actionIsReviewed(): boolean {
+    const action: string | undefined = this.context.payload.action;
+    return action == "submitted";
+  }
+
+  // review をしたユーザ名を取得
+  getUserName(): string {
+    const username: string = this.context.actor;
+    return username;
+  }
+
+  // Review によって Approved されているか？
+  isApproved(): boolean {
+    const state: string = this.context.payload.review.state;
+    return state == "approved";
+  }
+
   async addLabels(labels: string[]): Promise<void> {
     // Action実行時に取得できる情報
     // @see https://github.com/actions/toolkit/blob/825204968bef6c9829341275d8a35de5702dd965/packages/github/src/context.ts#L6
@@ -29,26 +57,33 @@ export class PullRequest {
     core.debug(JSON.stringify(result));
   }
 
-  hasAnyLabel(labels: string[]): boolean {
-    if (!this.context.payload.pull_request) {
-      return false;
-    }
-    const pullRequestLabels: string[] = this.context.payload.pull_request
-      .labels;
-
-    return pullRequestLabels.some(label => labels.includes(label));
+  // request Review
+  actionIsReviewRequested(): boolean {
+    const action: string | undefined = this.context.payload.action;
+    return action == "review_requested";
   }
 
-  // review 時の payload @see https://docs.github.com/en/rest/reference/pulls#reviews
-  // review をしたユーザ名を取得
-  getUserName(): string {
-    const username: string = this.context.actor;
+  // review を request したユーザ名を取得
+  getRequestedUserName(): string {
+    const username: string = this.context.payload.requested_reviewer.login;
     return username;
   }
 
-  // Review によって Approved されているか？
-  isApproved(): boolean {
-    const state: string = this.context.payload.review.state;
-    return state == "approved";
+  async rmLabel(name: string): Promise<void> {
+    // Action実行時に取得できる情報
+    // @see https://github.com/actions/toolkit/blob/825204968bef6c9829341275d8a35de5702dd965/packages/github/src/context.ts#L6
+    const { owner, repo, number: pull_number } = this.context.issue;
+    console.log(`owner: ${owner}`);
+    console.log(`repo: ${repo}`);
+    console.log(`pull_number: ${pull_number}`);
+
+    const result = await this.client.issues.removeLabel({
+      owner,
+      repo,
+      issue_number: pull_number,
+      name
+    });
+
+    core.debug(JSON.stringify(result));
   }
 }

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -15,12 +15,9 @@ export class PullRequest {
     if (!this.context.payload.pull_request) {
       return false;
     }
-    const pullRequestLabels: string[] = this.context.payload.pull_request
-      .labels;
-    console.log(pullRequestLabels);
-    console.log(labels);
+    const pullRequestLabels: any[] = this.context.payload.pull_request.labels;
 
-    return pullRequestLabels.some(label => labels.includes(label));
+    return pullRequestLabels.some(label => labels.includes(label.name));
   }
 
   // review 時の payload @see https://docs.github.com/en/rest/reference/pulls#reviews`


### PR DESCRIPTION
## 概要
Reviewを依頼したときにすでに付与されていたラベルを削除する機能を作成．
↓レビュー依頼はここから
<img src="https://user-images.githubusercontent.com/51741264/109679808-43b77a80-7bbf-11eb-91c7-e307474e46f7.png" width="25%">

テストが作成できていませんが動作確認したのでマージします
→ TODO：テスト作成

## 詳細（主に技術的変更点）
![スクリーンショット 2021-03-03 1 27 34](https://user-images.githubusercontent.com/51741264/109680223-a577e480-7bbf-11eb-82f2-721262d6678b.png)

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）

## 保留した項目・TODOリスト
- [ ] 時間の都合上テストを作成していません💦
→ PR出して動作確認済み

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
* PullRequest に関する発火イベント
https://docs.github.com/ja/developers/webhooks-and-events/github-event-types#pullrequestevent
* レビュー依頼時の github.context
https://github.com/shin-shin-01/label-when-approved-action/runs/2014396182?check_suite_focus=true
